### PR TITLE
Add EventClient.setUId, Remove paymentType on sendAddPaymentInfo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-client",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-client",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Ridibooks event tracking client",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",

--- a/src/eventClient.ts
+++ b/src/eventClient.ts
@@ -111,12 +111,8 @@ export class EventClient {
     this.sendEvent('BeginCheckout', { items }, ts);
   }
 
-  public sendAddPaymentInfo(
-    paymentType: string,
-    purchaseInfo: PurchaseInfo,
-    ts?: Date,
-  ): void {
-    this.sendEvent('AddPaymentInfo', { paymentType, ...purchaseInfo }, ts);
+  public sendAddPaymentInfo(purchaseInfo: PurchaseInfo, ts?: Date): void {
+    this.sendEvent('AddPaymentInfo', { ...purchaseInfo }, ts);
   }
 
   public sendEnrollPreference(items: Item[], ts?: Date): void {

--- a/src/eventClient.ts
+++ b/src/eventClient.ts
@@ -18,7 +18,7 @@ declare global {
 }
 
 export class EventClient {
-  private tagCalled = false;
+  private readonly tagCalled: boolean = false;
 
   constructor(private options: ClientOptions) {
     if (this.options.autoPageView === undefined) {
@@ -32,12 +32,6 @@ export class EventClient {
     this.pushDataLayer({ event: 'Init', ...options });
   }
 
-  public setUId(uId: number): void {
-    this.options.uId = uId;
-
-    this.pushDataLayer(this.options);
-  }
-
   private get dataLayer() {
     if (!this.tagCalled) {
       window.dataLayer = window.dataLayer || [];
@@ -46,11 +40,10 @@ export class EventClient {
     return window.dataLayer;
   }
 
-  private pushDataLayer(data: Record<string, any>): void {
-    if (!this.tagCalled) {
-      console.warn('[@ridi/ridi-event-client] GTM is not initialized.');
-    }
-    this.dataLayer.push(data);
+  public setUId(uId: number): void {
+    this.options.uId = uId;
+
+    this.pushDataLayer({ event: 'UIdChanged', ...this.options });
   }
 
   public sendEvent(
@@ -156,5 +149,12 @@ export class EventClient {
     ts?: Date,
   ): void {
     this.sendEvent('Purchase', { transactionId, ...purchaseInfo }, ts);
+  }
+
+  private pushDataLayer(data: Record<string, any>): void {
+    if (!this.tagCalled) {
+      console.warn('[@ridi/ridi-event-client] GTM is not initialized.');
+    }
+    this.dataLayer.push(data);
   }
 }

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -8,6 +8,11 @@ export interface Item {
   readonly item_episode_id?: string;
   readonly item_category: number;
   readonly item_genre?: string;
+  /**
+   * Original price of item that does not apply any discount
+   * @remarks price should be provided when event is AddPaymentInfo, Purchase
+   * @see {@link EventClient#sendPurchase}, {@link EventClient#sendAddPaymentInfo}
+   */
   readonly price?: number;
   readonly quantity: number;
 }


### PR DESCRIPTION
### 1. 변경 내용 요약

- `setUId` 메소드 실행시 event-tracker의 uid값도 변경되어야하므로 GTM에 `UIdChanged` 이벤트를 보내게 수정했습니다.
- `sendAddPaymentInfo` 메소드에서 `paymentType` 파라미터를 제거했습니다.

### 2. 중점적으로 리뷰받고 싶은 사항

- 

### 3. 배포 후

- 
