### PR TITLE
feat: PurchaseChargeAndPay 이벤트 추가 및 결제 파라미터 타입 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ridi/event-client",
-  "version": "0.2.16",
+  "version": "0.2.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ridi/event-client",
-      "version": "0.2.16",
+      "version": "0.2.20",
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.14.155",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-client",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Ridibooks event tracking client",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",

--- a/src/eventClient.ts
+++ b/src/eventClient.ts
@@ -158,10 +158,19 @@ export class EventClient {
 
   public sendPurchase(
     transactionId: string,
-    purchaseInfo: PurchaseInfo,
+    purchaseInfo: PurchaseInfo & Record<string, any>,
     ts?: Date,
   ): void {
     this.sendEvent('Purchase', { transactionId, ...purchaseInfo }, ts);
+  }
+
+
+  public sendPurchaseChargeAndPay(
+    transactionId: string,
+    purchaseInfo: PurchaseInfo & Record<string, any>,
+    ts?: Date,
+  ): void {
+    this.sendEvent('PurchaseChargeAndPay', { transactionId, ...purchaseInfo }, ts);
   }
 
   public sendUserAttribute(key: string, attr: UserAttribute, ts?: Date): void {


### PR DESCRIPTION
### 1. 변경 내용 요약
- 리디페이 충전후 결제 이벤트를 위한 `PurchaseChargeAndPay` 추가
- 결제 이벤트 추가 파라미터를 위한 타입 수정

